### PR TITLE
Add `namespace_labels` configuration for kubernetes plugin

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -56,6 +56,11 @@ kubernetes [ZONES...] {
 * `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
 * `namespaces` **NAMESPACE [NAMESPACE...]** only exposes the k8s namespaces listed.
    If this option is omitted all namespaces are exposed
+* `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.
+   The label selector syntax is described in the
+   [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/). An example that
+   only exposes namespaces labeled as "istio-injection=enabled", would use: 
+   `labels istio-injection=enabled`.
 * `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
    The label selector syntax is described in the
    [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -30,7 +30,7 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 	port := "*"
 	protocol := "*"
 	namespace := segs[last]
-	if !k.namespaceExposed(namespace) || !k.namespace(namespace) {
+	if !k.namespaceValid(namespace) {
 		return nil, dns.RcodeNameError
 	}
 

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -218,6 +218,15 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 		k.opts.selector = selector
 	}
 
+	if k.opts.namespaceLabelSelector != nil {
+		var selector labels.Selector
+		selector, err = meta.LabelSelectorAsSelector(k.opts.namespaceLabelSelector)
+		if err != nil {
+			return fmt.Errorf("unable to create Selector for LabelSelector '%s': %q", k.opts.namespaceLabelSelector, err)
+		}
+		k.opts.namespaceSelector = selector
+	}
+
 	k.opts.initPodCache = k.podMode == podModeVerified
 
 	k.opts.zones = k.Zones
@@ -241,7 +250,7 @@ func (k *Kubernetes) Records(state request.Request, exact bool) ([]msg.Service, 
 		return nil, errNoItems
 	}
 
-	if !wildcard(r.namespace) && !k.namespaceExposed(r.namespace) {
+	if !wildcard(r.namespace) && !k.namespaceValid(r.namespace) {
 		return nil, errNsNotExposed
 	}
 
@@ -303,13 +312,15 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	}
 
 	namespace := r.namespace
+	if !wildcard(namespace) && !k.namespaceValid(namespace) {
+		return nil, errNoItems
+	}
+
 	podname := r.service
-	zonePath := msg.Path(zone, coredns)
-	ip := ""
 
 	// handle empty pod name
 	if podname == "" {
-		if k.namespace(namespace) || wildcard(namespace) {
+		if k.namespaceValid(namespace) || wildcard(namespace) {
 			// NODATA
 			return nil, nil
 		}
@@ -317,6 +328,8 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 		return nil, errNoItems
 	}
 
+	zonePath := msg.Path(zone, coredns)
+	ip := ""
 	if strings.Count(podname, "-") == 3 && !strings.Contains(podname, "--") {
 		ip = strings.Replace(podname, "-", ".", -1)
 	} else {
@@ -324,7 +337,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	}
 
 	if k.podMode == podModeInsecure {
-		if !wildcard(namespace) && !k.namespace(namespace) { // no wildcard, but namespace does not exist
+		if !wildcard(namespace) && !k.namespaceValid(namespace) { // no wildcard, but namespace does not exist
 			return nil, errNoItems
 		}
 
@@ -339,15 +352,15 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	// PodModeVerified
 	err = errNoItems
 	if wildcard(podname) && !wildcard(namespace) {
-		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.namespace(namespace) {
+		// If namespace exists, err should be nil, so that we return NODATA instead of NXDOMAIN
+		if k.namespaceValid(namespace) {
 			err = nil
 		}
 	}
 
 	for _, p := range k.APIConn.PodIndex(ip) {
 		// If namespace has a wildcard, filter results against Corefile namespace list.
-		if wildcard(namespace) && !k.namespaceExposed(p.Namespace) {
+		if wildcard(namespace) && !k.namespaceValid(p.Namespace) {
 			continue
 		}
 
@@ -369,12 +382,24 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 
 // findServices returns the services matching r from the cache.
 func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.Service, err error) {
-	zonePath := msg.Path(zone, coredns)
+	if !wildcard(r.namespace) && !k.namespaceValid(r.namespace) {
+		return nil, errNoItems
+	}
+
+	// handle empty service name
+	if r.service == "" {
+		if k.namespaceValid(r.namespace) || wildcard(r.namespace) {
+			// NODATA
+			return nil, nil
+		}
+		// NXDOMAIN
+		return nil, errNoItems
+	}
 
 	err = errNoItems
 	if wildcard(r.service) && !wildcard(r.namespace) {
-		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.namespace(r.namespace) {
+		// If namespace exists, err should be nil, so that we return NODATA instead of NXDOMAIN
+		if k.namespaceValid(r.namespace) {
 			err = nil
 		}
 	}
@@ -385,16 +410,6 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		serviceList       []*object.Service
 	)
 
-	// handle empty service name
-	if r.service == "" {
-		if k.namespace(r.namespace) || wildcard(r.namespace) {
-			// NODATA
-			return nil, nil
-		}
-		// NXDOMAIN
-		return nil, errNoItems
-	}
-
 	if wildcard(r.service) || wildcard(r.namespace) {
 		serviceList = k.APIConn.ServiceList()
 		endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EndpointsList() }
@@ -404,14 +419,15 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EpIndex(idx) }
 	}
 
+	zonePath := msg.Path(zone, coredns)
 	for _, svc := range serviceList {
 		if !(match(r.namespace, svc.Namespace) && match(r.service, svc.Name)) {
 			continue
 		}
 
-		// If namespace has a wildcard, filter results against Corefile namespace list.
+		// If request namespace is a wildcard, filter results against Corefile namespace list.
 		// (Namespaces without a wildcard were filtered before the call to this function.)
-		if wildcard(r.namespace) && !k.namespaceExposed(svc.Namespace) {
+		if wildcard(r.namespace) && !k.namespaceValid(svc.Namespace) {
 			continue
 		}
 

--- a/plugin/kubernetes/namespace.go
+++ b/plugin/kubernetes/namespace.go
@@ -1,20 +1,27 @@
 package kubernetes
 
-// namespace checks if namespace n exists in this cluster. This returns true
-// even for non exposed namespaces, see namespaceExposed.
-func (k *Kubernetes) namespace(n string) bool {
-	ns, err := k.APIConn.GetNamespaceByName(n)
+// filteredNamespaceExists checks if namespace exists in this cluster
+// according to any `namespace_labels` plugin configuration specified.
+// Returns true even for namespaces not exposed by plugin configuration,
+// see namespaceExposed.
+func (k *Kubernetes) filteredNamespaceExists(namespace string) bool {
+	ns, err := k.APIConn.GetNamespaceByName(namespace)
 	if err != nil {
 		return false
 	}
-	return ns.ObjectMeta.Name == n
+	return ns.ObjectMeta.Name == namespace
 }
 
-// namespaceExposed returns true when the namespace is exposed.
+// namespaceExposed returns true when the namespace is exposed through the plugin
+// `namespaces` configuration.
 func (k *Kubernetes) namespaceExposed(namespace string) bool {
 	_, ok := k.Namespaces[namespace]
 	if len(k.Namespaces) > 0 && !ok {
 		return false
 	}
 	return true
+}
+
+func (k *Kubernetes) namespaceValid(namespace string) bool {
+	return k.namespaceExposed(namespace) && k.filteredNamespaceExists(namespace)
 }

--- a/plugin/kubernetes/namespace_test.go
+++ b/plugin/kubernetes/namespace_test.go
@@ -1,0 +1,72 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestFilteredNamespaceExists(t *testing.T) {
+	tests := []struct{
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{}, "foobar" },
+		{false, map[string]struct{}{}, "nsnoexist" },
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.filteredNamespaceExists(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Filtered namespace %s was expected to exist", i, test.testNamespace)
+		}
+	}
+}
+
+func TestNamespaceExposed(t *testing.T) {
+	tests := []struct{
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{ "foobar": {} }, "foobar" },
+		{false, map[string]struct{}{ "foobar": {} }, "nsnoexist" },
+		{true, map[string]struct{}{}, "foobar" },
+		{true, map[string]struct{}{}, "nsnoexist" },
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.namespaceExposed(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Namespace %s was expected to be exposed", i, test.testNamespace)
+		}
+	}
+}
+
+func TestNamespaceValid(t *testing.T) {
+	tests := []struct{
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{ "foobar": {} }, "foobar" },
+		{false, map[string]struct{}{ "foobar": {} }, "nsnoexist" },
+		{true, map[string]struct{}{}, "foobar" },
+		{false, map[string]struct{}{}, "nsnoexist" },
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.namespaceValid(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Namespace %s was expected to be valid", i, test.testNamespace)
+		}
+	}
+}

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -30,7 +30,7 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 	// First check services with cluster ips
 	for _, service := range k.APIConn.SvcIndexReverse(ip) {
-		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {
+		if len(k.Namespaces) > 0 && !k.namespaceValid(service.Namespace) {
 			continue
 		}
 		domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
@@ -38,7 +38,7 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 	}
 	// If no cluster ips match, search endpoints
 	for _, ep := range k.APIConn.EpIndexReverse(ip) {
-		if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.Namespace) {
+		if len(k.Namespaces) > 0 && !k.namespaceValid(ep.Namespace) {
 			continue
 		}
 		for _, eps := range ep.Subsets {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -240,6 +240,18 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				continue
 			}
 			return nil, c.ArgErr()
+		case "namespace_labels":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				namespaceLabelSelectorString := strings.Join(args, " ")
+				nls, err := meta.ParseToLabelSelector(namespaceLabelSelectorString)
+				if err != nil {
+					return nil, fmt.Errorf("unable to parse namespace_label selector value: '%v': %v", namespaceLabelSelectorString, err)
+				}
+				k8s.opts.namespaceLabelSelector = nls
+				continue
+			}
+			return nil, c.ArgErr()
 		case "fallthrough":
 			k8s.Fall.SetZonesFromArgs(c.RemainingArgs())
 		case "upstream":
@@ -297,6 +309,10 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 		default:
 			return nil, c.Errf("unknown property '%s'", c.Val())
 		}
+	}
+
+	if len(k8s.Namespaces) != 0 && k8s.opts.namespaceLabelSelector != nil {
+		return nil, c.Errf("namespaces and namespace_labels cannot both be set")
 	}
 
 	return k8s, nil

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -13,15 +13,16 @@ import (
 
 func TestKubernetesParse(t *testing.T) {
 	tests := []struct {
-		input                 string        // Corefile data as string
-		shouldErr             bool          // true if test case is expected to produce an error.
-		expectedErrContent    string        // substring from the expected error. Empty for positive cases.
-		expectedZoneCount     int           // expected count of defined zones.
-		expectedNSCount       int           // expected count of namespaces.
-		expectedResyncPeriod  time.Duration // expected resync period value
-		expectedLabelSelector string        // expected label selector value
-		expectedPodMode       string
-		expectedFallthrough   fall.F
+		input                          string        // Corefile data as string
+		shouldErr                      bool          // true if test case is expected to produce an error.
+		expectedErrContent             string        // substring from the expected error. Empty for positive cases.
+		expectedZoneCount              int           // expected count of defined zones.
+		expectedNSCount                int           // expected count of namespaces.
+		expectedResyncPeriod           time.Duration // expected resync period value
+		expectedLabelSelector          string        // expected label selector value
+		expectedNamespaceLabelSelector string        // expected namespace label selector value
+		expectedPodMode                string
+		expectedFallthrough            fall.F
 	}{
 		// positive
 		{
@@ -31,6 +32,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -43,6 +45,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -54,6 +57,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -68,6 +72,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -80,6 +85,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			1,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -94,6 +100,7 @@ func TestKubernetesParse(t *testing.T) {
 			2,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -106,6 +113,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			30 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -120,6 +128,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			15 * time.Minute,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -133,6 +142,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"environment=prod",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -146,6 +156,36 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"application=nginx,environment in (production,qa,staging)",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    namespace_labels istio-injection=enabled
+}`,
+			false,
+			"",
+			1,
+			0,
+			defaultResyncPeriod,
+			"",
+			"istio-injection=enabled",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    namespaces foo bar
+    namespace_labels istio-injection=enabled
+}`,
+			true,
+			"Error during parsing: namespaces and namespace_labels cannot both be set",
+			-1,
+			0,
+			defaultResyncPeriod,
+			"",
+			"istio-injection=enabled",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -163,6 +203,7 @@ func TestKubernetesParse(t *testing.T) {
 			2,
 			15 * time.Minute,
 			"application=nginx,environment in (production,qa,staging)",
+			"",
 			podModeDisabled,
 			fall.Root,
 		},
@@ -177,6 +218,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -189,6 +231,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			-1,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -203,6 +246,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Minute,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -215,6 +259,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			0 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -229,6 +274,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Second,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -242,6 +288,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Second,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -254,6 +301,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			0 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -269,6 +317,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -282,6 +331,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeInsecure,
 			fall.Zero,
@@ -297,6 +347,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeVerified,
 			fall.Zero,
 		},
@@ -310,6 +361,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeVerified,
 			fall.Zero,
@@ -325,6 +377,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.F{Zones: []string{"ip6.arpa.", "inaddr.arpa.", "foo.com."}},
 		},
@@ -339,6 +392,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -351,6 +405,7 @@ kubernetes cluster.local`,
 			-1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -365,6 +420,7 @@ kubernetes cluster.local`,
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -378,6 +434,7 @@ kubernetes cluster.local`,
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -390,6 +447,7 @@ kubernetes cluster.local`,
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -102,7 +102,7 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 	zonePath := msg.Path(zone, "coredns")
 	serviceList := k.APIConn.ServiceList()
 	for _, svc := range serviceList {
-		if !k.namespaceExposed(svc.Namespace) {
+		if !k.namespaceValid(svc.Namespace) {
 			continue
 		}
 		svcBase := []string{zonePath, Svc, svc.Namespace, svc.Name}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The current `kubernetes` plugin does not correctly support a `labels` configuration for namespaces. 

This is due the way the API watches are created for a namespace and pods/services/endpoints. A namespace specific label would not be configured on pods/services/endpoints and as a result, trying to specify a label on a namespace restricts watches on pods/services/endpoints that CoreDNS is aware about.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

The `kubernetes` plugin `README.md` documentation has been updated.